### PR TITLE
Expose PRD processing flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This MCP server is part of a complete task and memory management ecosystem:
 - `delete_task` - Delete task and all associated subtasks
 
 #### Advanced Task Management (AI Agent Tools)
-- `parse_prd` - Parse Product Requirements Documents and automatically generate structured tasks
+- `parse_prd` - Parse Product Requirements Documents and automatically generate structured tasks. Returns `processed: true` if tasks already exist for the project.
 - `get_next_task_recommendation` - Get intelligent task recommendations based on dependencies, priorities, and complexity
 - `analyze_task_complexity` - Analyze task complexity and suggest breaking down overly complex tasks
 - `infer_task_progress` - Analyze codebase to infer task completion status from implementation evidence

--- a/src/features/agent-memories/tools/memories/create.ts
+++ b/src/features/agent-memories/tools/memories/create.ts
@@ -105,7 +105,8 @@ Use the content field for detailed information.`
 **Metadata:** ${Object.keys(createdMemory.metadata).length > 0 ? JSON.stringify(createdMemory.metadata, null, 2) : 'None'}
 
 The memory has been stored and is ready for text-based search.`
-          }]
+          }],
+          recommendedNextStep: 'search_memories'
         };
       } catch (error) {
         return {

--- a/src/features/agent-memories/tools/memories/delete.ts
+++ b/src/features/agent-memories/tools/memories/delete.ts
@@ -91,7 +91,8 @@ The memory could not be deleted. Please try again.`
 • **Created:** ${new Date(memory.createdAt).toLocaleString()}
 
 The memory has been permanently removed from storage and cannot be recovered.`
-          }]
+          }],
+          recommendedNextStep: 'list_memories'
         };
       } catch (error) {
         return {

--- a/src/features/agent-memories/tools/memories/get.ts
+++ b/src/features/agent-memories/tools/memories/get.ts
@@ -55,7 +55,8 @@ The memory with this ID does not exist or may have been deleted.`
 **Created:** ${new Date(memory.createdAt).toLocaleString()}
 **Updated:** ${new Date(memory.updatedAt).toLocaleString()}
 **Metadata:** ${Object.keys(memory.metadata).length > 0 ? JSON.stringify(memory.metadata, null, 2) : 'None'}`
-          }]
+          }],
+          recommendedNextStep: 'update_memory'
         };
       } catch (error) {
         return {

--- a/src/features/agent-memories/tools/memories/list.ts
+++ b/src/features/agent-memories/tools/memories/list.ts
@@ -61,7 +61,8 @@ export function createListMemoriesTool(storage: MemoryStorage) {
               ].filter(Boolean).join(', ') || 'None'}
 
 Create some memories using the create_memory tool to get started!`
-            }]
+            }],
+            recommendedNextStep: 'create_memory'
           };
         }
 
@@ -101,7 +102,8 @@ ${memoryList}
 • Newest memory: ${stats.newestMemory ? new Date(stats.newestMemory).toLocaleString() : 'None'}
 
 Use get_memory with a specific ID to see full details, or search_memories for text-based search.`
-          }]
+          }],
+          recommendedNextStep: 'get_memory'
         };
       } catch (error) {
         return {

--- a/src/features/agent-memories/tools/memories/search.ts
+++ b/src/features/agent-memories/tools/memories/search.ts
@@ -121,7 +121,8 @@ Try adjusting your search query or using different keywords.`
             ].filter(Boolean).join(', ') || 'None'}
 
 ${resultText}`
-          }]
+          }],
+          recommendedNextStep: 'get_memory'
         };
       } catch (error) {
         return {

--- a/src/features/agent-memories/tools/memories/update.ts
+++ b/src/features/agent-memories/tools/memories/update.ts
@@ -166,7 +166,8 @@ The memory could not be updated. Please try again.`
 **Created:** ${new Date(updatedMemory.createdAt).toLocaleString()}
 **Updated:** ${new Date(updatedMemory.updatedAt).toLocaleString()}
 **Metadata:** ${Object.keys(updatedMemory.metadata).length > 0 ? JSON.stringify(updatedMemory.metadata, null, 2) : 'None'}`
-          }]
+          }],
+          recommendedNextStep: 'search_memories'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/analysis/complexity-analysis.ts
+++ b/src/features/task-management/tools/analysis/complexity-analysis.ts
@@ -8,7 +8,7 @@ import { Storage } from '../../storage/storage.js';
  */
 export function createComplexityAnalysisTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'analyze_task_complexity_Agentic_Tools',
+    name: 'analyze_task_complexity',
     description: 'Analyze task complexity and suggest breaking down overly complex tasks into smaller, manageable subtasks. Intelligent complexity analysis feature for better productivity and progress tracking.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),
@@ -88,7 +88,8 @@ export function createComplexityAnalysisTool(storage: Storage, getWorkingDirecto
           content: [{
             type: 'text' as const,
             text: report
-          }]
+          }],
+          recommendedNextStep: 'create_subtask'
         };
 
       } catch (error) {

--- a/src/features/task-management/tools/analysis/progress-inference.ts
+++ b/src/features/task-management/tools/analysis/progress-inference.ts
@@ -10,7 +10,7 @@ import { join, extname } from 'path';
  */
 export function createProgressInferenceTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'infer_task_progress_Agentic_Tools',
+    name: 'infer_task_progress',
     description: 'Analyze the codebase to infer which tasks appear to be completed based on code changes, file creation, and implementation evidence. Intelligent progress inference feature for automatic task completion tracking.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),
@@ -91,7 +91,8 @@ export function createProgressInferenceTool(storage: Storage, getWorkingDirector
           content: [{
             type: 'text' as const,
             text: report
-          }]
+          }],
+          recommendedNextStep: 'update_task'
         };
 
       } catch (error) {

--- a/src/features/task-management/tools/projects/create.ts
+++ b/src/features/task-management/tools/projects/create.ts
@@ -95,7 +95,8 @@ Description: ${createdProject.description}
 Created: ${new Date(createdProject.createdAt).toLocaleString()}
 
 You can now add tasks to this project using the create_task tool.`
-          }]
+          }],
+          recommendedNextStep: 'create_task'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/projects/delete.ts
+++ b/src/features/task-management/tools/projects/delete.ts
@@ -75,7 +75,8 @@ export function createDeleteProjectTool(storage: Storage) {
 **Also deleted:** ${tasks.length} task(s) and ${subtasks.length} subtask(s)
 
 This action cannot be undone. All data associated with this project has been permanently removed.`
-          }]
+          }],
+          recommendedNextStep: 'list_projects'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/projects/get.ts
+++ b/src/features/task-management/tools/projects/get.ts
@@ -64,7 +64,8 @@ export function createGetProjectTool(storage: Storage) {
 Tasks: ${completedTasks}/${tasks.length} completed${subtaskSummary}
 
 Use list_tasks with projectId="${project.id}" to see all tasks in this project.`
-          }]
+          }],
+          recommendedNextStep: 'list_tasks'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/projects/list.ts
+++ b/src/features/task-management/tools/projects/list.ts
@@ -20,7 +20,8 @@ export function createListProjectsTool(storage: Storage) {
             content: [{
               type: 'text' as const,
               text: 'No projects found. Create your first project to get started!'
-            }]
+            }],
+            recommendedNextStep: 'create_project'
           };
         }
 
@@ -35,7 +36,8 @@ Updated: ${new Date(project.updatedAt).toLocaleString()}`;
           content: [{
             type: 'text' as const,
             text: `Found ${projects.length} project(s):\n\n${projectList}`
-          }]
+          }],
+          recommendedNextStep: 'create_project'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/projects/update.ts
+++ b/src/features/task-management/tools/projects/update.ts
@@ -145,7 +145,8 @@ Description: ${updatedProject.description}
 Last Updated: ${new Date(updatedProject.updatedAt).toLocaleString()}
 
 Updated fields: ${changedFields.join(', ')}`
-          }]
+          }],
+          recommendedNextStep: 'list_tasks'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/recommendations/next-task.ts
+++ b/src/features/task-management/tools/recommendations/next-task.ts
@@ -8,7 +8,7 @@ import { Storage } from '../../storage/storage.js';
  */
 export function createNextTaskRecommendationTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'get_next_task_recommendation_Agentic_Tools',
+    name: 'get_next_task_recommendation',
     description: 'Get intelligent recommendations for the next task to work on based on dependencies, priorities, complexity, and current project status. Smart task recommendation engine for optimal workflow management.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),
@@ -83,7 +83,8 @@ ${generateTaskStatusSummary(allTasks)}
           content: [{
             type: 'text' as const,
             text: report
-          }]
+          }],
+          recommendedNextStep: 'research_task'
         };
 
       } catch (error) {

--- a/src/features/task-management/tools/research/research-queries.ts
+++ b/src/features/task-management/tools/research/research-queries.ts
@@ -13,7 +13,7 @@ export function createResearchQueriesGeneratorTool(
   config: any
 ) {
   return {
-    name: 'generate_research_queries_Agentic_Tools',
+    name: 'generate_research_queries',
     description: 'Generate intelligent, targeted web search queries for task research. Provides structured search strategies to help AI agents find the most relevant information efficiently.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),
@@ -84,7 +84,8 @@ ${queries.flatMap(section =>
 - Add "tutorial" or "guide" to queries when you need step-by-step instructions
 - Include the current year (${targetYear}) for the most recent information
 - Check multiple sources to verify information accuracy`
-          }]
+          }],
+          recommendedNextStep: 'research_task'
         };
 
       } catch (error) {

--- a/src/features/task-management/tools/research/task-research.ts
+++ b/src/features/task-management/tools/research/task-research.ts
@@ -14,7 +14,7 @@ export function createTaskResearchTool(
   config: any
 ) {
   return {
-    name: 'research_task_Agentic_Tools',
+    name: 'research_task',
     description: 'Guide the AI agent to perform comprehensive web research for a task, with intelligent research suggestions and automatic memory storage of findings. Combines web research capabilities with local knowledge caching.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),
@@ -95,7 +95,8 @@ ${memoryInstructions}
 2. Adjust complexity/priority if research reveals new information
 3. Consider breaking down the task if research shows it's more complex than expected
 4. Use \`get_next_task_recommendation\` to see if this task is now ready to start`
-          }]
+          }],
+          recommendedNextStep: 'update_task'
         };
 
       } catch (error) {

--- a/src/features/task-management/tools/subtasks/create.ts
+++ b/src/features/task-management/tools/subtasks/create.ts
@@ -128,7 +128,8 @@ Status: Pending
 Created: ${new Date(createdSubtask.createdAt).toLocaleString()}
 
 You can mark this subtask as completed using update_subtask.`
-          }]
+          }],
+          recommendedNextStep: 'update_subtask'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/subtasks/delete.ts
+++ b/src/features/task-management/tools/subtasks/delete.ts
@@ -79,7 +79,8 @@ export function createDeleteSubtaskTool(storage: Storage) {
 **Project:** ${projectName}
 
 This action cannot be undone. The subtask has been permanently removed.`
-          }]
+          }],
+          recommendedNextStep: 'list_subtasks'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/subtasks/get.ts
+++ b/src/features/task-management/tools/subtasks/get.ts
@@ -61,7 +61,8 @@ export function createGetSubtaskTool(storage: Storage) {
 **Last Updated:** ${new Date(subtask.updatedAt).toLocaleString()}
 
 Use update_subtask to modify this subtask or mark it as completed.`
-          }]
+          }],
+          recommendedNextStep: 'update_subtask'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/subtasks/list.ts
+++ b/src/features/task-management/tools/subtasks/list.ts
@@ -61,7 +61,8 @@ export function createListSubtasksTool(storage: Storage) {
             content: [{
               type: 'text' as const,
               text: message
-            }]
+            }],
+            recommendedNextStep: 'create_subtask'
           };
         }
 
@@ -120,7 +121,8 @@ Updated: ${new Date(subtask.updatedAt).toLocaleString()}`;
           content: [{
             type: 'text' as const,
             text: `${headerText}\n\n${subtaskList}`
-          }]
+          }],
+          recommendedNextStep: 'update_subtask'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/subtasks/update.ts
+++ b/src/features/task-management/tools/subtasks/update.ts
@@ -163,7 +163,8 @@ Details: ${updatedSubtask.details}
 Last Updated: ${new Date(updatedSubtask.updatedAt).toLocaleString()}
 
 Updated fields: ${changedFields.join(', ')}`
-          }]
+          }],
+          recommendedNextStep: 'list_subtasks'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/tasks/create.ts
+++ b/src/features/task-management/tools/tasks/create.ts
@@ -168,7 +168,8 @@ Created: ${new Date(createdTask.createdAt).toLocaleString()}
 • Use \`get_next_task_recommendation\` to see if this task is ready to work on
 • Add subtasks using \`create_subtask\` for complex tasks
 • Update progress using \`update_task\` as you work`
-          }]
+          }],
+          recommendedNextStep: 'get_next_task_recommendation'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/tasks/delete.ts
+++ b/src/features/task-management/tools/tasks/delete.ts
@@ -79,7 +79,8 @@ export function createDeleteTaskTool(storage: Storage) {
 **Also deleted:** ${subtasks.length} subtask(s)
 
 This action cannot be undone. All data associated with this task has been permanently removed.`
-          }]
+          }],
+          recommendedNextStep: 'list_tasks'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/tasks/get.ts
+++ b/src/features/task-management/tools/tasks/get.ts
@@ -65,7 +65,8 @@ export function createGetTaskTool(storage: Storage) {
 **Last Updated:** ${new Date(task.updatedAt).toLocaleString()}${subtaskSummary}
 
 Use list_subtasks with taskId="${task.id}" to see all subtasks for this task.`
-          }]
+          }],
+          recommendedNextStep: 'list_subtasks'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/tasks/list.ts
+++ b/src/features/task-management/tools/tasks/list.ts
@@ -41,7 +41,8 @@ export function createListTasksTool(storage: Storage) {
             content: [{
               type: 'text' as const,
               text: message
-            }]
+            }],
+            recommendedNextStep: 'create_task'
           };
         }
 
@@ -87,7 +88,8 @@ Updated: ${new Date(task.updatedAt).toLocaleString()}`;
           content: [{
             type: 'text' as const,
             text: `${headerText}\n\n${taskList}`
-          }]
+          }],
+          recommendedNextStep: 'get_next_task_recommendation'
         };
       } catch (error) {
         return {

--- a/src/features/task-management/tools/tasks/update.ts
+++ b/src/features/task-management/tools/tasks/update.ts
@@ -252,7 +252,8 @@ Updated fields: ${changedFields.join(', ')}
 🎯 **Next Steps:**
 • Use \`get_next_task_recommendation\` to see what to work on next
 • Run \`analyze_task_complexity\` if complexity has changed`
-          }]
+          }],
+          recommendedNextStep: 'get_next_task_recommendation'
         };
       } catch (error) {
         return {


### PR DESCRIPTION
## Summary
- report whether the PRD has been processed for a project
- skip task generation if tasks already exist and return `processed: true`
- document the new `processed` property in README