### PR TITLE
Refactor: Remove _Agentic_Tools suffix from tool names

### DIFF
--- a/src/features/task-management/tools/analysis/complexity-analysis.ts
+++ b/src/features/task-management/tools/analysis/complexity-analysis.ts
@@ -8,7 +8,7 @@ import { Storage } from '../../storage/storage.js';
  */
 export function createComplexityAnalysisTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'analyze_task_complexity_Agentic_Tools',
+    name: 'analyze_task_complexity',
     description: 'Analyze task complexity and suggest breaking down overly complex tasks into smaller, manageable subtasks. Intelligent complexity analysis feature for better productivity and progress tracking.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),

--- a/src/features/task-management/tools/analysis/progress-inference.ts
+++ b/src/features/task-management/tools/analysis/progress-inference.ts
@@ -10,7 +10,7 @@ import { join, extname } from 'path';
  */
 export function createProgressInferenceTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'infer_task_progress_Agentic_Tools',
+    name: 'infer_task_progress',
     description: 'Analyze the codebase to infer which tasks appear to be completed based on code changes, file creation, and implementation evidence. Intelligent progress inference feature for automatic task completion tracking.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),

--- a/src/features/task-management/tools/prd/parse-prd.ts
+++ b/src/features/task-management/tools/prd/parse-prd.ts
@@ -10,7 +10,7 @@ import { Storage } from '../../storage/storage.js';
  */
 export function createParsePRDTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'parse_prd_Agentic_Tools',
+    name: 'parse_prd',
     description: 'Parse a Product Requirements Document (PRD) and automatically generate structured tasks with dependencies, priorities, and complexity estimates. This tool analyzes PRD content and creates a comprehensive task breakdown with intelligent analysis.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),

--- a/src/features/task-management/tools/recommendations/next-task.ts
+++ b/src/features/task-management/tools/recommendations/next-task.ts
@@ -8,7 +8,7 @@ import { Storage } from '../../storage/storage.js';
  */
 export function createNextTaskRecommendationTool(storage: Storage, getWorkingDirectoryDescription: (config: any) => string, config: any) {
   return {
-    name: 'get_next_task_recommendation_Agentic_Tools',
+    name: 'get_next_task_recommendation',
     description: 'Get intelligent recommendations for the next task to work on based on dependencies, priorities, complexity, and current project status. Smart task recommendation engine for optimal workflow management.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),

--- a/src/features/task-management/tools/research/research-queries.ts
+++ b/src/features/task-management/tools/research/research-queries.ts
@@ -13,7 +13,7 @@ export function createResearchQueriesGeneratorTool(
   config: any
 ) {
   return {
-    name: 'generate_research_queries_Agentic_Tools',
+    name: 'generate_research_queries',
     description: 'Generate intelligent, targeted web search queries for task research. Provides structured search strategies to help AI agents find the most relevant information efficiently.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),

--- a/src/features/task-management/tools/research/task-research.ts
+++ b/src/features/task-management/tools/research/task-research.ts
@@ -14,7 +14,7 @@ export function createTaskResearchTool(
   config: any
 ) {
   return {
-    name: 'research_task_Agentic_Tools',
+    name: 'research_task',
     description: 'Guide the AI agent to perform comprehensive web research for a task, with intelligent research suggestions and automatic memory storage of findings. Combines web research capabilities with local knowledge caching.',
     inputSchema: z.object({
       workingDirectory: z.string().describe(getWorkingDirectoryDescription(config)),


### PR DESCRIPTION
This commit removes the _Agentic_Tools suffix from MCP server tool names where it was present.

The affected tools are:
- analyze_task_complexity
- infer_task_progress
- parse_prd
- get_next_task_recommendation
- generate_research_queries
- research_task

No changes were needed in server.ts as it already used the correct names for registration.